### PR TITLE
Feature/immediate steps execution

### DIFF
--- a/.changeset/small-terms-itch.md
+++ b/.changeset/small-terms-itch.md
@@ -1,0 +1,5 @@
+---
+'@amwpcn/step': patch
+---
+
+immediate step execution feature

--- a/packages/examples/src/step/custom-steps/cleanup.step.ts
+++ b/packages/examples/src/step/custom-steps/cleanup.step.ts
@@ -1,0 +1,19 @@
+import { IContext, IHandlers, Step } from '@amwpcn/step';
+import { simulateAsyncTask } from '../helpers';
+
+interface CleanupContext extends IContext {}
+
+export class CleanupStep extends Step<CleanupContext> {
+  readonly name: string = 'CleanupStep';
+
+  async execute(
+    context: Readonly<CleanupContext>,
+    handlers: IHandlers<CleanupContext>,
+  ): Promise<void | Step<IContext>[] | Step<IContext>> {
+    await simulateAsyncTask();
+  }
+}
+
+export function cleanup() {
+  return new CleanupStep();
+}

--- a/packages/examples/src/step/custom-steps/import-document.step.ts
+++ b/packages/examples/src/step/custom-steps/import-document.step.ts
@@ -1,5 +1,6 @@
 import { IContext, IHandlers, Step } from '@amwpcn/step';
 import { simulateAsyncTask } from '../helpers';
+import { updateDocumentCount } from './update-document-count.step';
 
 interface ImportDocumentContext extends IContext {}
 
@@ -13,6 +14,7 @@ export class ImportDocumentStep extends Step<ImportDocumentContext> {
     await simulateAsyncTask();
 
     // this.enqueueAfter(importDocument(), 0);
+    return updateDocumentCount();
   }
 }
 

--- a/packages/examples/src/step/custom-steps/index.ts
+++ b/packages/examples/src/step/custom-steps/index.ts
@@ -1,2 +1,3 @@
+export * from './cleanup.step';
 export * from './import-document.step';
 export * from './update-document-count.step';

--- a/packages/examples/src/step/index.ts
+++ b/packages/examples/src/step/index.ts
@@ -1,9 +1,12 @@
 import { createExecutor } from '@amwpcn/step';
-import { importDocument, updateDocumentCount } from './custom-steps';
+import { cleanup, importDocument } from './custom-steps';
 
 async function main() {
-  const step = importDocument().enqueueAfter(updateDocumentCount(), 0);
-  const executor = createExecutor([step, step], {}, undefined, {
+  const step = importDocument()
+    .enqueueBefore(cleanup(), 0)
+    .enqueueAfter(cleanup(), 1);
+
+  const executor = createExecutor(step, {}, undefined, {
     graph: { enable: true },
     maxRepetitions: 2,
     concurrency: {


### PR DESCRIPTION
`execute` function of each step can now return one or more steps. These returned steps will be executed parallelly and immediately after the execution of the current step, but before the steps in the after-queue of the current step.